### PR TITLE
Added Vercel Rewrite Rule to Fix 404 On Page Refresh (#48)  

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,9 @@
+{
+    "rewrites": [
+      {
+        "source": "/(.*)",
+        "destination": "/index.html"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
**Hi team 👋**  
This PR resolves #48 by updating the Vercel deployment configuration to ensure deep links and page refreshes correctly load routed pages, removing the persistent 404 error.

***

### 🔍 Problem Resolved:
- A Vercel 404 error appeared when refreshing or directly accessing internal routes like `/explore`, rather than rendering the intended page.
- This was caused by Vercel seeking static files for dynamic routes instead of passing them to the SPA router.

***

### ✅ What’s Changed:
- Updated the deployment configuration to add a rewrite rule, so all requests for routes are handled by the SPA and no longer produce Vercel’s default 404 error.
- Improved site behavior so navigation and direct URL access are seamless.

***


### 🎯 Result / Benefit:
- Eliminates puzzling 404 errors for users.
- Consistent SPA navigation experience—users always get the right page.

***

### 🏷 Labels Requested:
- `gssoc2025`
- `level 1`
- `frontend`
- `bug`